### PR TITLE
Change how debops.gitlab test is structured

### DIFF
--- a/ansible-gitlab/inventory/group_vars/all.yml
+++ b/ansible-gitlab/inventory/group_vars/all.yml
@@ -1,10 +1,16 @@
 ---
 
+# Disable PKI support in nginx
+nginx_pki: False
+
 # Currently tested GitLab version on Travis-CI
 gitlab_version: '6.7'
 
 # Default domain on Travis-CI
 gitlab_domain: [ 'localhost.localdomain' ]
+
+# Don't add 'git' user to additional groups
+gitlab_user_append_groups: []
 
 # Travis does not support filesystem ACL, so give access to the webserver via
 # group permissions

--- a/ansible-gitlab/playbooks/test.yml
+++ b/ansible-gitlab/playbooks/test.yml
@@ -4,14 +4,6 @@
   sudo: True
 
   roles:
-      # Nginx requires configured SSL certificates
-    - role: 'debops.pki'
-
-      # GitLab requires 'sshusers' system group
-    - role: 'debops.auth'
-
-      # Install standard set of packages
-    - role: 'debops.apt'
 
       # Install and configure GitLab using cloned role
     - role: 'ansible-gitlab'

--- a/ansible-gitlab/test
+++ b/ansible-gitlab/test
@@ -21,9 +21,6 @@ install_ansible v1.8.2
 ansible_plugins
 
 
-ansible-galaxy install -f debops.pki debops.apt debops.auth
-
-
 assert_playbook_runs
 assert_playbook_idempotent
 


### PR DESCRIPTION
Drop reliance on SSL for nginx, omit certain system groups in the test.