### PR TITLE
add test authorized_keys role debops.users

### DIFF
--- a/ansible-users/inventory/group_vars/all.yml
+++ b/ansible-users/inventory/group_vars/all.yml
@@ -21,3 +21,6 @@ users_host_list:
     # The default shell is bash and dotfiles are disabled by default.
     shell: '/bin/zsh'
     dotfiles: True
+    sshkeys:
+      - 'ssh-rsa 000000 test'
+

--- a/ansible-users/test
+++ b/ansible-users/test
@@ -22,6 +22,7 @@ assert_playbook_idempotent
 
 assert_path "/tmp/testuser"
 assert_path "/tmp/testuser/.config/dotfiles"
+assert_path "/tmp/testuser/.ssh/authorized_keys"
 
 assert_user_in_group "testuser" "audio"
 


### PR DESCRIPTION
I noted that the creation of the file is not tested for keys