### PR TITLE
Use stable ansible-2.0

### DIFF
--- a/ansible-slapd/test
+++ b/ansible-slapd/test
@@ -9,7 +9,7 @@
 . "${ROLESPEC_TEST}/../defaults.conf"
 
 
-install_ansible ${test_ansible_version}
+install_ansible stable-2.0
 ansible_plugins
 
 


### PR DESCRIPTION
This should fix the `debops.slapd ` rolespec failures mentioned in debops/ansible-slapd#27 (together with debops/ansible-slapd#28)