### PR TITLE
Don't use hostname as Travis-CI will fail with it

### DIFF
--- a/ansible-elasticsearch/inventory/group_vars/all.yml
+++ b/ansible-elasticsearch/inventory/group_vars/all.yml
@@ -1,5 +1,5 @@
 ---
 
 elasticsearch_bind_host: ['0.0.0.0']
-elasticsearch_node_allow: '{{ groups["debops_elasticsearch"] }}'
-elasticsearch_http_allow: '{{ groups["debops_elasticsearch"] }}'
+elasticsearch_node_allow: ['127.0.0.1']
+elasticsearch_http_allow: ['127.0.0.1']


### PR DESCRIPTION
```
fatal: [testing-gce-66e82c1a-2cca-43da-859b-2ad3ad0c9b04]: FAILED! =>
  {"changed": false,
   "failed": true,
   "msg": "ip6tables v1.4.12: host/network `testing-gce-66e82c1a-2cca-43da-859b-2ad3ad0c9b04' not found
           Try `ip6tables -h' or 'ip6tables --help' for more information.

           Firewall rules rolled back."
  }
```