### PR TITLE
Adjust playbook according to debops-contrib/checkmk_server#14

### DIFF
--- a/ansible-checkmk_server/playbooks/test.yml
+++ b/ansible-checkmk_server/playbooks/test.yml
@@ -6,9 +6,7 @@
   roles:
 
     - role: debops.ferm
-      tags: [ 'role::ferm' ]
-      ferm__dependent_rules: '{{ checkmk_server__ferm_dependent_rules }}'
-      when: checkmk_server__dependencies | bool
+      ferm__dependent_rules:
+        - '{{ checkmk_server__ferm_dependent_rules }}'
 
     - role: ansible-checkmk_server
-      tags: [ 'role::checkmk_server' ]


### PR DESCRIPTION
Add another commit which I forgot to nurse in my `checkmk_server` branch. With this, debops-contrib/checkmk_server#56 should eventually pass. 