### PR TITLE
Add rolespec test for debops-contrib.roundcube

### DIFF
--- a/ansible-roundcube/inventory/group_vars/all/common
+++ b/ansible-roundcube/inventory/group_vars/all/common
@@ -1,0 +1,1 @@
+../../../../common-ansible-inventory/group_vars/all/common

--- a/ansible-roundcube/inventory/group_vars/all/roundcube/roundcube.yml
+++ b/ansible-roundcube/inventory/group_vars/all/roundcube/roundcube.yml
@@ -1,0 +1,4 @@
+---
+
+roundcube_domain: [ 'localhost.localdomain' ]
+

--- a/ansible-roundcube/inventory/group_vars/all/roundcube/roundcube.yml
+++ b/ansible-roundcube/inventory/group_vars/all/roundcube/roundcube.yml
@@ -1,4 +1,0 @@
----
-
-roundcube_domain: [ 'localhost.localdomain' ]
-

--- a/ansible-roundcube/inventory/hosts
+++ b/ansible-roundcube/inventory/hosts
@@ -1,0 +1,1 @@
+placeholder_fqdn

--- a/ansible-roundcube/playbooks/test.yml
+++ b/ansible-roundcube/playbooks/test.yml
@@ -7,16 +7,16 @@
 
     - role: debops.php5
       php5_packages:
-        - '{{ roundcube_php5_packages }}'
+        - '{{ roundcube__php5_packages }}'
       php5_pools:
-        - '{{ roundcube_php5_pool }}'
+        - '{{ roundcube__php5_pool }}'
       when: roundcube_dependencies|d()
 
     - role: debops.nginx
       nginx_servers:
-        - '{{ roundcube_nginx_server }}'
+        - '{{ roundcube__nginx_server }}'
       nginx_upstreams:
-        - '{{ roundcube_nginx_upstream_php5 }}'
+        - '{{ roundcube__nginx_upstream_php5 }}'
       when: roundcube_dependencies|d()
 
     - role: 'ansible-roundcube'

--- a/ansible-roundcube/playbooks/test.yml
+++ b/ansible-roundcube/playbooks/test.yml
@@ -3,6 +3,10 @@
 - hosts: 'placeholder_fqdn'
   become: True
 
+  environment: '{{ inventory__environment | d({})
+                   | combine(inventory__group_environment | d({}))
+                   | combine(inventory__host_environment  | d({})) }}'
+
   roles:
 
     - role: debops.php5
@@ -10,14 +14,12 @@
         - '{{ roundcube__php5_packages }}'
       php5_pools:
         - '{{ roundcube__php5_pool }}'
-      when: roundcube_dependencies|d()
 
     - role: debops.nginx
       nginx_servers:
         - '{{ roundcube__nginx_server }}'
       nginx_upstreams:
         - '{{ roundcube__nginx_upstream_php5 }}'
-      when: roundcube_dependencies|d()
 
     - role: 'ansible-roundcube'
 

--- a/ansible-roundcube/playbooks/test.yml
+++ b/ansible-roundcube/playbooks/test.yml
@@ -1,0 +1,23 @@
+---
+
+- hosts: 'placeholder_fqdn'
+  become: True
+
+  roles:
+
+    - role: debops.php5
+      php5_packages:
+        - '{{ roundcube_php5_packages }}'
+      php5_pools:
+        - '{{ roundcube_php5_pool }}'
+      when: roundcube_dependencies|d()
+
+    - role: debops.nginx
+      nginx_servers:
+        - '{{ roundcube_nginx_server }}'
+      nginx_upstreams:
+        - '{{ roundcube_nginx_upstream_php5 }}'
+      when: roundcube_dependencies|d()
+
+    - role: 'ansible-roundcube'
+

--- a/ansible-roundcube/playbooks/test.yml
+++ b/ansible-roundcube/playbooks/test.yml
@@ -8,18 +8,28 @@
                    | combine(inventory__host_environment  | d({})) }}'
 
   roles:
+    - role: debops.php/env
 
-    - role: debops.php5
-      php5_packages:
-        - '{{ roundcube__php5_packages }}'
-      php5_pools:
-        - '{{ roundcube__php5_pool }}'
+    - role: debops.apt_preferences
+      apt_preferences__dependent_list:
+        - '{{ nginx__apt_preferences__dependent_list }}'
+        - '{{ php__apt_preferences__dependent_list }}'
+
+    - role: debops.ferm
+      ferm__dependent_rules:
+        - '{{ nginx__ferm__dependent_rules }}'
+
+    - role: debops.php
+      php__dependent_packages:
+        - '{{ roundcube__php__dependent_packages }}'
+      php__dependent_pools:
+        - '{{ roundcube__php__dependent_pools }}'
 
     - role: debops.nginx
-      nginx_servers:
-        - '{{ roundcube__nginx_server }}'
-      nginx_upstreams:
-        - '{{ roundcube__nginx_upstream_php5 }}'
+      nginx__dependent_servers:
+        - '{{ roundcube__nginx__dependent_servers }}'
+      nginx__dependent_upstreams:
+        - '{{ roundcube__nginx__dependent_upstreams }}'
 
     - role: 'ansible-roundcube'
 

--- a/ansible-roundcube/test
+++ b/ansible-roundcube/test
@@ -15,7 +15,6 @@ ansible_plugins
 
 ansible-galaxy -f install debops.php5
 ansible-galaxy -f install debops.nginx
-ansible-galaxy -f install debops.mariadb
 
 
 # Use Trusty packages for more recent PHP5 support

--- a/ansible-roundcube/test
+++ b/ansible-roundcube/test
@@ -1,0 +1,32 @@
+#!/bin/bash
+
+# test: Test debops.owncloud
+# Copyright (C) 2014 Nick Janetakis <nick.janetakis@gmail.com>
+# Part of the DebOps project - http://debops.org/
+
+
+. "${ROLESPEC_LIB}/main"
+. "${ROLESPEC_TEST}/../defaults.conf"
+
+
+install_ansible ${test_ansible_version}
+ansible_plugins
+
+
+ansible-galaxy -f install debops.php5
+ansible-galaxy -f install debops.nginx
+
+
+# Use Trusty packages for more recent PHP5 support
+echo "deb http://us.archive.ubuntu.com/ubuntu/ trusty main restricted universe multiverse" | sudo tee /etc/apt/sources.list.d/trusty.list
+sudo apt-get -qq update
+
+
+assert_playbook_check_runs
+assert_playbook_idempotent
+
+
+assert_path "/var/www/roundcube"
+
+assert_docs
+

--- a/ansible-roundcube/test
+++ b/ansible-roundcube/test
@@ -15,6 +15,7 @@ ansible_plugins
 
 ansible-galaxy -f install debops.php5
 ansible-galaxy -f install debops.nginx
+ansible-galaxy -f install debops.mariadb
 
 
 # Use Trusty packages for more recent PHP5 support

--- a/ansible-roundcube/test
+++ b/ansible-roundcube/test
@@ -26,7 +26,7 @@ assert_playbook_check_runs
 assert_playbook_idempotent
 
 
-assert_path "/var/www/roundcube"
+assert_path "/srv/www/roundcube"
 
 assert_docs
 

--- a/ansible-roundcube/test
+++ b/ansible-roundcube/test
@@ -20,6 +20,16 @@ assert_playbook_check_runs
 assert_playbook_idempotent
 
 
-assert_path "/srv/www/roundcube"
+assert_path '/srv/www/sites/roundcube.localdomain/public'
+
+assert_running nginx
+assert_running php-fpm
+
+sudo echo '127.0.0.1 roundcube.localdomain' >> /etc/hosts
+
+assert_url 'http://roundcube.localdomain'
+
+test -s /srv/www/sites/roundcube.localdomain/public/logs/error &&
+    cat /srv/www/sites/roundcube.localdomain/public/logs/error
 
 assert_docs

--- a/ansible-roundcube/test
+++ b/ansible-roundcube/test
@@ -13,10 +13,7 @@ install_ansible ${test_ansible_version}
 ansible_plugins
 
 
-ansible-galaxy -f install debops.apt_preferences debops.ferm debops.nginx
-ansible-galaxy -f install git+https://github.com/ganto/ansible-php.git,pkg-filter
-# create symlink for correct role naming
-ln -s ansible-php roles/debops.php
+ansible-galaxy -f install debops.apt_preferences debops.ferm debops.php debops.nginx
 
 
 assert_playbook_check_runs

--- a/ansible-roundcube/test
+++ b/ansible-roundcube/test
@@ -13,7 +13,10 @@ install_ansible ${test_ansible_version}
 ansible_plugins
 
 
-ansible-galaxy -f install debops.apt_preferences debops.ferm debops.php debops.nginx
+ansible-galaxy -f install debops.apt_preferences debops.ferm debops.nginx
+ansible-galaxy -f install git+https://github.com/ganto/ansible-php.git,pkg-filter
+# create symlink for correct role naming
+ln -s ansible-php roles/debops.php
 
 
 assert_playbook_check_runs

--- a/ansible-roundcube/test
+++ b/ansible-roundcube/test
@@ -25,8 +25,9 @@ assert_path '/srv/www/sites/roundcube.localdomain/public'
 assert_running nginx
 assert_running php-fpm
 
-sudo echo '127.0.0.1 roundcube.localdomain' >> /etc/hosts
+sudo sed -i '$ a 127.0.0.1 roundcube.localdomain' /etc/hosts
 
+curl 'http://roundcube.localdomain'
 assert_url 'http://roundcube.localdomain'
 
 test -s /srv/www/sites/roundcube.localdomain/public/logs/error &&

--- a/ansible-roundcube/test
+++ b/ansible-roundcube/test
@@ -13,13 +13,7 @@ install_ansible ${test_ansible_version}
 ansible_plugins
 
 
-ansible-galaxy -f install debops.php5
-ansible-galaxy -f install debops.nginx
-
-
-# Use Trusty packages for more recent PHP5 support
-echo "deb http://us.archive.ubuntu.com/ubuntu/ trusty main restricted universe multiverse" | sudo tee /etc/apt/sources.list.d/trusty.list
-sudo apt-get -qq update
+ansible-galaxy -f install debops.apt_preferences debops.ferm debops.php debops.nginx
 
 
 assert_playbook_check_runs
@@ -29,4 +23,3 @@ assert_playbook_idempotent
 assert_path "/srv/www/roundcube"
 
 assert_docs
-


### PR DESCRIPTION
Before I merge the changes from debops-contrib/ansible-roundcube#24 I would like to change the test-suite to the official DebOps tests. Like this it's easier to spot issues in the common parts and allows me to run rolespec tests from my personal clone against a modified test suite.