### PR TITLE
Retry role installation due to connectivity issues with github

### DIFF
--- a/ansible-checkmk_server/test
+++ b/ansible-checkmk_server/test
@@ -12,7 +12,8 @@
 install_ansible ${test_ansible_version}
 ansible_plugins
 
-ansible-galaxy -f install debops.ferm
+until ansible-galaxy install debops.ferm ; do
+        echo "Waiting 60s..." ; sleep 60 ; echo "Trying installation again..." ; done
 
 assert_playbook_check_runs
 assert_playbook_idempotent


### PR DESCRIPTION
Fixes:
```
  - downloading role 'ferm', owned by debops
  - downloading role from https://github.com/debops/ansible-ferm/archive/v0.3.0.tar.gz

  [ERROR]: failed to download the file: (104, 'Connection reset by peer')

  [WARNING]: - debops.ferm was NOT installed successfully.
```